### PR TITLE
Update obsolete URL for goplay.x1unix.com

### DIFF
--- a/LITERATURE.md
+++ b/LITERATURE.md
@@ -166,7 +166,7 @@ https://henvic.dev/posts/go/
 ### Плейграунды
 * https://play.golang.org/
 * https://goplay.space/
-* https://goplay.x1unix.com/
+* https://goplay.tools/
 
 ### Роутеры:
 * https://github.com/gorilla/mux


### PR DESCRIPTION
`goplay.x1unix.com` давно переехал на домен https://goplay.tools